### PR TITLE
func 'availables', define variable 'f' to None BEFORE the try/except …

### DIFF
--- a/lib/python3.8/site-packages/Freshen/__init__.py
+++ b/lib/python3.8/site-packages/Freshen/__init__.py
@@ -25,7 +25,7 @@ from Freshen.update import Update
 from Freshen.exceptions import InstallationError, CacheWarning
 from Freshen.request import FreshenRequest as Request
 
-version = {'major': 3, 'minor': 1, 'revision': 1, 'prerelease': 'dev'}
+version = {'major': 3, 'minor': 1, 'revision': 2, 'prerelease': 'dev'}
 requiredVersions = {
     'Scripts': '017-GIT',
     'Compile': '017-GIT',
@@ -518,6 +518,7 @@ def availables(forceNoCache=False):
     cacheFile = _cacheFile(0, 'availables.cache')
     if (not forceNoCache and os.path.exists(cacheFile) and
           (time.time() - os.path.getmtime(cacheFile) < 1800)):
+        f = None
         try:
             f = open(cacheFile, 'r')
             return pickle.load(f)
@@ -531,6 +532,7 @@ def availables(forceNoCache=False):
             types=['installed', 'local_package', 'official_package',
             'recipe', 'contrib_package', 'tracked'],
             hook=consoleProgressHook)
+        f = None
         try:
             f = open(cacheFile, 'wb')
             pickle.dump(avs, f,


### PR DESCRIPTION
…statement

Python was throwing an error that 'f' was not defined, in the 'finally' block. Error was shown when multiple instances of the program requested access to the 'cacheFile' simultaneously.

quick fix: defined 'f' BEFORE the try/except/finally statement to make sure the variable was defined and in scope.