### PR TITLE
close all files+pipes explicitly

### DIFF
--- a/lib/python3.8/site-packages/Freshen/ArgParser.py
+++ b/lib/python3.8/site-packages/Freshen/ArgParser.py
@@ -33,9 +33,11 @@ class FreshenArgParser:
         goboUserSettings = getGoboVariable('goboUserSettings')
         conffile = os.path.join(goboUserSettings, 'Freshen.conf')
         if os.path.exists(conffile):
+            f = open(conffile)
             sys.argv = (sys.argv[0:1] +
-                        map(str.strip, open(conffile)) +
+                        map(str.strip, f) +
                         sys.argv[1:])
+            f.close()
         self.fetched = True
         self.skipSet = set()
         self.examineSet = set()

--- a/lib/python3.8/site-packages/Freshen/__init__.py
+++ b/lib/python3.8/site-packages/Freshen/__init__.py
@@ -172,12 +172,17 @@ def _program_updates_each(upd, examinedProgram, req):
         current = set()
         uf = '%s/%s/Current/Resources/UseFlags' % (goboPrograms, upd.program)
         if (latestInstalled(upd.program) and os.path.exists(uf)):
+            f = None
             try:
-                current = set(open(uf).readline().split())
+                f = open(uf)
+                current = set(f.readline().split())
             except:
                 Log_Error('Resources/UseFlags data file for '
                           'installed %s exists but is not '
                           'readable.' % (upd.program), 'Freshen')
+            finally:
+                if f:
+                    f.close()
         else:
             current = set()
         if current != activeFlags and not _skip(upd, req):
@@ -518,19 +523,22 @@ def availables(forceNoCache=False):
     cacheFile = _cacheFile(0, 'availables.cache')
     if (not forceNoCache and os.path.exists(cacheFile) and
           (time.time() - os.path.getmtime(cacheFile) < 1800)):
+        f = None
         try:
             f = open(cacheFile, 'r')
             return pickle.load(f)
         except:
             return availables(True)
         finally:
-            f.close()
+            if f:
+                f.close()
     else:
         consoleProgressHook.endString = '\015'
         avs = GetAvailable(
             types=['installed', 'local_package', 'official_package',
             'recipe', 'contrib_package', 'tracked'],
             hook=consoleProgressHook)
+        f = None
         try:
             f = open(cacheFile, 'wb')
             pickle.dump(avs, f,

--- a/lib/python3.8/site-packages/FreshenUI.py
+++ b/lib/python3.8/site-packages/FreshenUI.py
@@ -123,16 +123,21 @@ class FreshenUI:
                     and os.path.exists(self.goboPrograms + '/'
                                         + update.program +
                                         '/Current/Resources/UseFlags')):
+                    f = None
                     try:
-                        currentFlags = set(open(
-                                                self.goboPrograms +
-                                                '/' + update.program +
-                                                '/Current/Resources/UseFlags')
-                                            .readline().split())
+                        f = open(
+                                self.goboPrograms +
+                                '/' + update.program +
+                                '/Current/Resources/UseFlags')
+
+                        currentFlags = set(f.readline().split())
                     except:
                         Log_Error('Resources/UseFlags data file for '
                                     'installed %s exists but is not '
                                     'readable.' % (update.program), 'Freshen')
+                    finally:
+                        if f:
+                            f.close()
                 else:
                     currentFlags = set()
 
@@ -406,8 +411,9 @@ class FreshenUI:
                 ulist.append(u)
                 rec = None
                 if u.type != 'alien':
-                    rec = (os.popen('GetRecipe %s %s' % (program, ver))
-                             .readline().strip() + '/Recipe')
+                    p = os.popen('GetRecipe %s %s' % (program, ver))
+                    rec = (p.readline().strip() + '/Recipe')
+                    p.close()
                 if rec and os.path.exists(rec):
                     file = open(rec, 'r')
                     for line in file:
@@ -611,13 +617,22 @@ def reportBug(exc_info):
                         '.'.join(map(str, sys.version_info)) + '\n')
     compileVersion = 'unknown'
     scriptsVersion = 'unknown'
+    compile_pipe = None
+    script_pipe = None
     try:
+        compile_pipe = os.popen('which Compile')
         compileVersion = re.search('Compile/([^/]+)/',
-                                os.popen('which Compile').read()).groups()[0]
+                                compile_pipe.read()).groups()[0]
+        script_pipe = os.popen('which UseFlags')
         scriptsVersion = re.search('Scripts/([^/]+)/',
-                                os.popen('which UseFlags').read()).groups()[0]
+                                script_pipe.read()).groups()[0]
     except:
         pass
+    finally:
+        if compile_pipe:
+            compile_pipe.close()
+        if script_pipe:
+            script_pipe.close()
     sys.stderr.write('with Scripts %s and Compile %s\n\n' %
         (scriptsVersion, compileVersion))
     sys.stderr.write('arguments: %r\n'%(sys.argv))

--- a/lib/python3.8/site-packages/TTYUtils.py
+++ b/lib/python3.8/site-packages/TTYUtils.py
@@ -20,8 +20,9 @@ import sys
 class Screen:
     """Access to TTY metadata."""
 
-    height, width = [int(x) for x in os.popen('stty size')
-                                       .readline().strip().split(' ')]
+    p = os.popen('stty size')
+    height, width = [int(x) for x in p.readline().strip().split(' ')]
+    p.close()
     colours = {'red': "\033[1;31m",
                'blue': "\033[1;34m",
                'green': "\033[0;32m",


### PR DESCRIPTION
It is poor practice to open a resource, file, or pipe without closing it. For details on why, see Ian Currie's article, _[Why Is It Important to Close Files in Python?](https://realpython.com/why-close-file-python/)_.

- Used grep to find all occurrences of `open` and `popen` function/method calls
- Save the returned handles into variables.
- After the handle is no longer needed, free it using the `close` method
- Fix a couple of faulty `try-except-finally` blocks

**note:** not python3 exclusive, just general principle