### PR TITLE
fix a crash when processing Freshen.conf

### DIFF
--- a/lib/python3.8/site-packages/Freshen/ArgParser.py
+++ b/lib/python3.8/site-packages/Freshen/ArgParser.py
@@ -33,11 +33,17 @@ class FreshenArgParser:
         goboUserSettings = getGoboVariable('goboUserSettings')
         conffile = os.path.join(goboUserSettings, 'Freshen.conf')
         if os.path.exists(conffile):
-            f = open(conffile)
-            sys.argv = (sys.argv[0:1] +
-                        map(str.strip, f) +
-                        sys.argv[1:])
-            f.close()
+            f = None
+            try:
+                f = open(conffile, "r")
+                sys.argv = (sys.argv[0:1] +
+                            [*map(str.strip, f.readlines())] +
+                            sys.argv[1:])
+            except:
+                pass
+            finally:
+                if f:
+                    f.close()
         self.fetched = True
         self.skipSet = set()
         self.examineSet = set()


### PR DESCRIPTION
If the `Freshen.conf` file existed, the Freshen program would crash when reaching the `fetch` function. Inside the function, the script attempted to concatenate incompatible types of `List` and `Map`.

- Open the file with error catching
- Read each line of `Freshen.conf` into an `Iterable` type
- Cast the returned `Map` to type `List` _(using python 3.5 magic)_
