### PR TITLE
revert test_open's mode check back to using write (rather than binary write)

### DIFF
--- a/lib/python3.8/site-packages/Freshen/__init__.py
+++ b/lib/python3.8/site-packages/Freshen/__init__.py
@@ -619,7 +619,7 @@ if __name__ == '__main__':
     def test_open(filename, mode='r'):
         """Replacement for open, using StringIO for testing."""
         file = StringIO.StringIO()
-        if 'wb' in mode:
+        if 'w' in mode:
             print("<<Test open method: saving to %s>>" % (
                 filename.rpartition('/')[2]))
             file.write = lambda x: sys.stdout.write(


### PR DESCRIPTION
when converting code to run on python3.x, all file write modes (`'w'`) were converted to binary writes (`'wb'`). This change was to allow pickled data to be written into cache files without error. However, this change was also applied to the `test_open` function, where a distinction between binary and text modes is potentially problematic.

- Reverted `test_open`'s mode check back to using `'w'`.

This update is not _needed_ given the current source, however, it may save a headache or two in the future.